### PR TITLE
feat: Implement `runInBackground` method for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ use the `event()` method to do that for you, passing in the name of the event to
 $schedule->event('Foo')->hourly();
 ```
 
+### Running Command In Background 
+
+If you want to run a command in background, you can use the `runInBackground()` method to do that for you,
+so the command won't block the execution of the next schedulers.
+
+> [!Note]
+> Currently only **commands** are able to run in background
+
+```php
+$schedule->command('slow-command')->runInBackground()->hourly();
+```
+
+It prevents the command from blocking the execution of the next schedulers.
+
 ### Running On One server
 
 If your scheduler runs on multiple servers, you can determine if your scheduled job 
@@ -161,7 +175,7 @@ will executes in a single or in multiple servers using the `setRunType` method.
 
 ```php
 $schedule->event('Foo')->setRunType('multiple')->hourly(); // Runs in all servers
-$schedule->event('Foo')->setRunType('single')->hourly(); // Runs in one servers
+$schedule->event('Foo')->setRunType('single')->hourly(); // Runs in one server
 ```
 This prevents duplication of tasks across servers by securing a lock on the job, 
 ensuring it runs exclusively on the first server that obtains it.

--- a/src/Commands/Finish.php
+++ b/src/Commands/Finish.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Daycry\CronJob\Commands;
+
+use CodeIgniter\I18n\Time;
+use Daycry\CronJob\Job;
+use Daycry\CronJob\JobRunner;
+
+/**
+ * Finish Running Command
+ */
+class Finish extends CronJobCommand
+{
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'cronjob:finish';
+
+    /**
+     * the Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'Finishes Running CronJob';
+
+    /**
+     * the Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'cronjob:finish --type <task-type> --name <task-name>';
+
+    /**
+     * Enables task running
+     *
+     * @param array{
+     *     type: string,
+     *     name: string,
+     * } $params
+     * @throws \Exception
+     */
+    public function run(array $params): void
+    {
+        if (!isset($params['type']) || !isset($params['name'])) {
+            $this->showHelp();
+            return;
+        }
+
+        $name = $params['name'];
+
+        $task = new Job($params['type'], $name);
+
+        $task->named($name);
+
+        $info = $task->getIsRunningInfo();
+
+        // If the task was not running we don't need to do anything
+        if ($info === null) {
+            return;
+        }
+
+        $startAt = $info['time'];
+
+        $task
+            ->startLog($startAt)
+            ->endLog()
+            ->saveRunningFlag(false);
+
+        (new JobRunner)->sendCronJobFinishesEmailNotification(
+            $task,
+            new Time($startAt)
+        );
+    }
+}

--- a/src/Exceptions/TaskAlreadyRunningException.php
+++ b/src/Exceptions/TaskAlreadyRunningException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Daycry\CronJob\Exceptions;
+
+use Daycry\CronJob\Job;
+
+class TaskAlreadyRunningException extends CronJobException
+{
+    public function __construct(Job $task)
+    {
+        parent::__construct(
+            sprintf('%s is single run task and one instance is already running.', $task->getName() ?: 'Task')
+        );
+    }
+}

--- a/src/Traits/InteractsWithSpark.php
+++ b/src/Traits/InteractsWithSpark.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Daycry\CronJob\Traits;
+
+trait InteractsWithSpark
+{
+    public function sparkPath(): string
+    {
+        return FCPATH . '../spark';
+    }
+
+    public function sparkCommandInBackground(string $command): string
+    {
+        return sprintf(
+            '%s %s %s',
+            PHP_BINARY,
+            $this->sparkPath(),
+            $command,
+        );
+    }
+}

--- a/src/Traits/StatusTrait.php
+++ b/src/Traits/StatusTrait.php
@@ -2,51 +2,84 @@
 
 namespace Daycry\CronJob\Traits;
 
+use Daycry\CronJob\Job;
+
 /**
  * Trait StatusTrait
  *
+ * @mixin Job
  * @package Daycry\CronJob
  */
 trait StatusTrait
 {
+    protected function isRunningFlagPath(): string
+    {
+        return setting('CronJob.filePath') . 'running/' . $this->getName();
+    }
+
+    protected function createConfigFolderIfNeeded(): void
+    {
+        $folder = setting('CronJob.filePath');
+
+        if (is_dir($folder)) {
+            return;
+        }
+
+        mkdir($folder);
+    }
+
+    protected function createTasksRunningFolderIfNeeded(): void
+    {
+        $folder = setting('CronJob.filePath') . 'running';
+
+        if (is_dir($folder)) {
+            return;
+        }
+
+        mkdir($folder);
+    }
+
+    protected function createFoldersIfNeeded(): void
+    {
+        $this->createConfigFolderIfNeeded();
+        $this->createTasksRunningFolderIfNeeded();
+    }
+
     /**
      * Saves the running flag.
      */
     public function saveRunningFlag($flag)
     {
-        $config = config('CronJob');
+        $name = $this->getName();
 
-        $name = ($this->name) ? $this->name : $this->buildName();
+        $path = $this->isRunningFlagPath();
+
         if ($flag) {
-            if (!file_exists(setting('CronJob.filePath') . 'running/' . $name)) {
-                // dir doesn't exist, make it
-                if (!is_dir(setting('CronJob.filePath'))) {
-                    mkdir(setting('CronJob.filePath'));
-                }
-
-                if (!is_dir(setting('CronJob.filePath') . 'running/')) {
-                    mkdir(setting('CronJob.filePath') . 'running/');
-                }
-
-                $data = [
-                    "flag" => $flag,
-                    "time" => (new \DateTime())->format('Y-m-d H:i:s')
-                ];
-
-                // write the file with json content
-                file_put_contents(
-                    setting('CronJob.filePath') . '/running/' . $name,
-                    json_encode(
-                        $data,
-                        JSON_PRETTY_PRINT
-                    )
-                );
-
-                return $data;
+            if (file_exists($path)) {
+                return false;
             }
+
+            $this->createFoldersIfNeeded();
+
+            $data = [
+                "flag" => $flag,
+                "time" => (new \DateTime())->format('Y-m-d H:i:s')
+            ];
+
+            // write the file with json content
+            file_put_contents(
+                $path,
+                json_encode(
+                    $data,
+                    JSON_PRETTY_PRINT
+                )
+            );
+
+            return $data;
         } else {
             @unlink(setting('CronJob.filePath') . '/running/' . $name);
         }
+
         return false;
     }
 
@@ -119,5 +152,24 @@ trait StatusTrait
         }
 
         return false;
+    }
+
+    /**
+     * @return ?array{
+     *     name: string,
+     *     time: string,
+     * }
+     */
+    public function getIsRunningInfo(): ?array
+    {
+        $path = $this->isRunningFlagPath();
+
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        $content = file_get_contents($path);
+
+        return json_decode($content, true);
     }
 }

--- a/tests/unit/JobTest.php
+++ b/tests/unit/JobTest.php
@@ -156,4 +156,17 @@ final class JobTest extends TestCase
         $this->assertInstanceOf(Time::class, $job->lastRun()); // @phpstan-ignore-line
         $this->assertSame($date, $job->lastRun()->format('Y-m-d H:i:s'));
     }
+
+    public function testShouldRunInBackgroundProperty(): void
+    {
+        $job = new Job('command', 'app:info');
+
+        // by default, it should be false
+        $this->assertFalse($job->shouldRunInBackground());
+
+        $job->runInBackground();
+
+        // after we call `runInBackground`, it should be true
+        $this->assertTrue($job->shouldRunInBackground());
+    }
 }


### PR DESCRIPTION
### Description

```php
$schedule->command('slow-command')->runInBackground()->hourly();
```

This PR adds an option to configure a scheduled command to run in the background. This feature is particularly useful for jobs that take a significant amount of time to complete, as it prevents subsequent scheduled jobs from being delayed.


### Implementation Details

By default, commands are triggered by calling the CI helper:

```php
command('command:name');
```

When a job is configured to run in the background, this default behavior is bypassed. Instead, the job is executed using the current shell execution:

```bash
/usr/bin/php spark command:name && cronjob:finish --name command:name --type command
```

### Key Components:

  - PHP_BINARY: This constant provides the path to the PHP binary (/usr/bin/php).
  - FCPATH: This constant is used to determine the path for the spark executable.

Additionally, the `cronjob:finish` command is responsible for setting the cronjob status to "stopped," allowing it to run again without issues.