### PR TITLE
Fix getting filePath and fileName from main config file

### DIFF
--- a/src/Commands/CronJobCommand.php
+++ b/src/Commands/CronJobCommand.php
@@ -34,10 +34,10 @@ abstract class CronJobCommand extends BaseCommand
     {
         $this->getConfig();
 
-        if (!file_exists($this->configfilePath .$this->configfileName)) {
+        if (!file_exists($this->config->filePath .$this->config->fileName)) {
             // dir doesn't exist, make it
-            if (!is_dir($this->configfilePath)) {
-                mkdir($this->configfilePath);
+            if (!is_dir($this->config->filePath)) {
+                mkdir($this->config->filePath);
             }
 
             $settings = [
@@ -47,7 +47,7 @@ abstract class CronJobCommand extends BaseCommand
 
             // write the file with json content
             file_put_contents(
-                $this->configfilePath . $this->configfileName,
+                $this->config->filePath . $this->config->fileName,
                 json_encode(
                     $settings,
                     JSON_PRETTY_PRINT
@@ -68,8 +68,8 @@ abstract class CronJobCommand extends BaseCommand
     {
         $this->getConfig();
 
-        if (file_exists($this->configfilePath . $this->configfileName)) {
-            $data = json_decode(file_get_contents($this->configfilePath . $this->configfileName));
+        if (file_exists($this->config->filePath . $this->config->fileName)) {
+            $data = json_decode(file_get_contents($this->config->filePath . $this->config->fileName));
             return $data;
         }
 

--- a/src/Commands/Disable.php
+++ b/src/Commands/Disable.php
@@ -41,7 +41,7 @@ class Disable extends CronJobCommand
         $this->getConfig();
 
         //delete the file with json content
-        @unlink($this->configfilePath . $this->configfileName);
+        @unlink($this->config->filePath . $this->config->fileName);
 
         $this->disabled();
     }


### PR DESCRIPTION
Fixes #40.

There is no property named `configfilePath` or `configfileName`.  However, there is `filePath` and `fileName` inside the `Config/CronJob.php` files.

So, let's use `->config->filePath` and `->config->fileName` instead.